### PR TITLE
update packages to fix npm audit issues

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ function DiskCache(rootPath, options) {
     });
 
     // Bind methods
-    _.bindAll(this);
+    _.bindAll(this, _.keys(DiskCache.prototype));
 
     // Pending writes
     this.pending = {};

--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
     },
     "dependencies": {
         "q": "^1.4.1",
-        "lodash": "^3.10.1",
-        "lru-cache": "^4.0.0",
+        "lodash": "^4.17.10",
+        "lru-cache": "^4.1.3",
         "fs-extra": "^0.26.5",
         "tmp": "^0.0.28",
         "crc": "^3.4.0",
         "fswrite-stream": "^1.0.0"
     },
     "devDependencies": {
-        "mocha": "2.4.5",
-        "should": "8.2.2"
+        "mocha": "^5.2.0",
+        "should": "^11.1.0"
     },
     "scripts": {
         "test": "node_modules/.bin/mocha --reporter spec --timeout 15000"


### PR DESCRIPTION
fixes `npm audit` vulnerabilities.

lodash is a major version update, noted that it affected the _.bindAll call, so have updated so that it has same behaviour as before.

lru-cache minor version bump

mocha & should major version bumps however devDependency and all tests still pass, so should be okay.